### PR TITLE
Add method to set SO_REUSEADDR on vio sockets

### DIFF
--- a/src/libmowgli/vio/vio.c
+++ b/src/libmowgli/vio/vio.c
@@ -41,6 +41,7 @@ mowgli_vio_ops_t mowgli_vio_default_ops = {
 	.bind = mowgli_vio_default_bind,
 	.listen = mowgli_vio_default_listen,
 	.accept = mowgli_vio_default_accept,
+	.reuseaddr = mowgli_vio_default_reuseaddr,
 	.connect = mowgli_vio_default_connect,
 	.read = mowgli_vio_default_read,
 	.write = mowgli_vio_default_write,

--- a/src/libmowgli/vio/vio.h
+++ b/src/libmowgli/vio/vio.h
@@ -38,6 +38,7 @@ typedef enum {
 	MOWGLI_VIO_ERR_OP_SOCKET,
 	MOWGLI_VIO_ERR_OP_LISTEN,
 	MOWGLI_VIO_ERR_OP_ACCEPT,
+	MOWGLI_VIO_ERR_OP_REUSEADDR,
 	MOWGLI_VIO_ERR_OP_CONNECT,
 	MOWGLI_VIO_ERR_OP_READ,
 	MOWGLI_VIO_ERR_OP_WRITE,
@@ -94,6 +95,7 @@ typedef struct {
 	mowgli_vio_bind_connect_func_t *connect;
 	mowgli_vio_listen_func_t *listen;
 	mowgli_vio_accept_func_t *accept;
+	mowgli_vio_func_t *reuseaddr;
 	mowgli_vio_read_func_t *read;
 	mowgli_vio_write_func_t *write;
 	mowgli_vio_sendto_func_t *sendto;
@@ -250,6 +252,7 @@ extern int mowgli_vio_default_socket(mowgli_vio_t *vio, int family, int type, in
 extern int mowgli_vio_default_bind(mowgli_vio_t *vio, mowgli_vio_sockaddr_t *addr);
 extern int mowgli_vio_default_listen(mowgli_vio_t *vio, int backlog);
 extern int mowgli_vio_default_accept(mowgli_vio_t *vio, mowgli_vio_t *newvio);
+extern int mowgli_vio_default_reuseaddr(mowgli_vio_t *vio);
 extern int mowgli_vio_default_connect(mowgli_vio_t *vio, mowgli_vio_sockaddr_t *addr);
 extern int mowgli_vio_default_read(mowgli_vio_t *vio, void *buffer, size_t len);
 extern int mowgli_vio_default_write(mowgli_vio_t *vio, const void *buffer, size_t len);
@@ -300,6 +303,7 @@ extern mowgli_vio_evops_t mowgli_vio_default_evops;
 #define mowgli_vio_listen(vio, ...)	vio->ops->listen(vio, __VA_ARGS__)
 #define mowgli_vio_bind(vio, ...)	vio->ops->bind(vio, __VA_ARGS__)
 #define mowgli_vio_accept(vio, ...)	vio->ops->accept(vio, __VA_ARGS__)
+#define mowgli_vio_reuseaddr(vio)	vio->ops->reuseaddr(vio)
 #define mowgli_vio_connect(vio, ...)	vio->ops->connect(vio, __VA_ARGS__)
 #define mowgli_vio_read(vio, ...)	vio->ops->read(vio, __VA_ARGS__)
 #define mowgli_vio_write(vio, ...)	vio->ops->write(vio, __VA_ARGS__)

--- a/src/libmowgli/vio/vio_sockets.c
+++ b/src/libmowgli/vio/vio_sockets.c
@@ -121,6 +121,22 @@ int mowgli_vio_default_accept(mowgli_vio_t *vio, mowgli_vio_t *newvio)
 	return 0;
 }
 
+int mowgli_vio_default_reuseaddr(mowgli_vio_t *vio)
+{
+	int fd = mowgli_vio_getfd(vio);
+	int reuse = 1;
+
+	return_val_if_fail(fd != -1, -255);
+
+	vio->error.op = MOWGLI_VIO_ERR_OP_REUSEADDR;
+
+	if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
+		return mowgli_vio_err_errcode(vio, strerror, errno);
+
+	vio->error.op = MOWGLI_VIO_ERR_OP_NONE;
+	return 0;
+}
+
 int mowgli_vio_default_connect(mowgli_vio_t *vio, mowgli_vio_sockaddr_t *addr)
 {
 	const int fd = mowgli_vio_getfd(vio);


### PR DESCRIPTION
This commit adds a function mowgli_vio_default_reuseaddr to set the SO_REUSEADDR option on a socket. It also adds the necessary typedefs, struct members, etc. to integrate it with the rest of the vio API.
