### PR TITLE
Linebuf shutdown

### DIFF
--- a/src/libmowgli/linebuf/linebuf.c
+++ b/src/libmowgli/linebuf/linebuf.c
@@ -252,14 +252,11 @@ void mowgli_linebuf_write(mowgli_linebuf_t *linebuf, const char *data, int len)
 	mowgli_pollable_setselect(linebuf->eventloop, linebuf->vio->io, MOWGLI_EVENTLOOP_IO_WRITE, mowgli_linebuf_write_data);
 }
 
-void mowgli_linebuf_shut_down(mowgli_linebuf_t *linebuf, mowgli_linebuf_shutdown_cb_t *cb)
+void mowgli_linebuf_shut_down(mowgli_linebuf_t *linebuf)
 {
 	return_if_fail(linebuf != NULL);
-	/* A null callback makes no sense. Just close your socket, bro. */
-	return_if_fail(cb != NULL);
 
 	linebuf->flags |= MOWGLI_LINEBUF_SHUTTING_DOWN;
-	linebuf->shutdown_cb = cb;
 
 	if (linebuf->writebuf.buflen == 0)
 		mowgli_linebuf_do_shutdown(linebuf);

--- a/src/libmowgli/linebuf/linebuf.h
+++ b/src/libmowgli/linebuf/linebuf.h
@@ -38,7 +38,7 @@ extern void mowgli_linebuf_destroy(mowgli_linebuf_t *linebuf);
 extern void mowgli_linebuf_setbuflen(mowgli_linebuf_buf_t *buffer, size_t buflen);
 extern void mowgli_linebuf_write(mowgli_linebuf_t *linebuf, const char *data, int len);
 extern void mowgli_linebuf_writef(mowgli_linebuf_t *linebuf, const char *format, ...);
-extern void mowgli_linebuf_shut_down(mowgli_linebuf_t *linebuf, mowgli_linebuf_shutdown_cb_t *cb);
+extern void mowgli_linebuf_shut_down(mowgli_linebuf_t *linebuf);
 
 struct _mowgli_linebuf_buf {
 	char *buffer;


### PR DESCRIPTION
Generalizes shutdown_cb to be called whenever the remote host closes the connection as well.
