### PR TITLE
Fix build of ext/json.

### DIFF
--- a/src/libmowgli/ext/json.h
+++ b/src/libmowgli/ext/json.h
@@ -113,7 +113,7 @@ extern mowgli_json_t *mowgli_json_create_float(double v_float);
 /* #define mowgli_json_create_number(V) _Generic((V), \
 	int: mowgli_json_create_integer, \
 	double: mowgli_json_create_float)(V) */
-extern mowgli_json_t *mowgli_json_create_string_n(const char *str, unsigned len);
+extern mowgli_json_t *mowgli_json_create_string_n(const char *str, size_t len);
 extern mowgli_json_t *mowgli_json_create_string(const char *str);
 extern mowgli_json_t *mowgli_json_create_array(void);
 extern mowgli_json_t *mowgli_json_create_object(void);


### PR DESCRIPTION
```
json.c:174:16: error: conflicting types for ‘mowgli_json_create_string_n’
../ext/json.h:116:23: note: previous declaration of ‘mowgli_json_create_string_n’ was here
```
