### PR TITLE
Fixes for C++ compilers

### DIFF
--- a/src/libmowgli/ext/json-inline.h
+++ b/src/libmowgli/ext/json-inline.h
@@ -80,12 +80,12 @@ static inline void mowgli_json_object_add(mowgli_json_t *obj, const char *key, m
 
 static inline mowgli_json_t *mowgli_json_object_retrieve(mowgli_json_t *obj, const char *key)
 {
-	return mowgli_patricia_retrieve(MOWGLI_JSON_OBJECT(obj), key);
+	return (mowgli_json_t*)mowgli_patricia_retrieve(MOWGLI_JSON_OBJECT(obj), key);
 }
 
 static inline mowgli_json_t *mowgli_json_object_delete(mowgli_json_t *obj, const char *key)
 {
-	return mowgli_patricia_delete(MOWGLI_JSON_OBJECT(obj), key);
+	return (mowgli_json_t*)mowgli_patricia_delete(MOWGLI_JSON_OBJECT(obj), key);
 }
 
 #endif

--- a/src/libmowgli/ext/json.h
+++ b/src/libmowgli/ext/json.h
@@ -42,12 +42,7 @@
 #define MOWGLI_JSON_H
 
 /* Types with public definitons */
-typedef enum _mowgli_json_tag_t mowgli_json_tag_t;
-typedef struct _mowgli_json_t mowgli_json_t;
-/* Types whose definitons are kept private */
-typedef struct _mowgli_json_parse_t mowgli_json_parse_t;
-
-enum _mowgli_json_tag_t {
+typedef enum {
 	MOWGLI_JSON_TAG_NULL,
 	MOWGLI_JSON_TAG_BOOLEAN,
 	/* JSON does not distinguish between integers or floating points
@@ -58,7 +53,10 @@ enum _mowgli_json_tag_t {
 	MOWGLI_JSON_TAG_STRING,
 	MOWGLI_JSON_TAG_ARRAY,
 	MOWGLI_JSON_TAG_OBJECT,
-};
+} mowgli_json_tag_t;
+typedef struct _mowgli_json_t mowgli_json_t;
+/* Types whose definitons are kept private */
+typedef struct _mowgli_json_parse_t mowgli_json_parse_t;
 
 struct _mowgli_json_t {
 	mowgli_json_tag_t tag;


### PR DESCRIPTION
```
/usr/include/libmowgli-2/ext/json.h:45:14: error: use of enum ‘_mowgli_json_tag_t’ without previous declaration
/usr/include/libmowgli-2/ext/json.h:45:50: error: invalid type in declaration before ‘;’ token`
```

```
/usr/include/libmowgli-2/ext/json-inline.h: In function ‘mowgli_json_t* mowgli_json_object_retrieve(mowgli_json_t*, const char*)’:
/usr/include/libmowgli-2/ext/json-inline.h:83:62: error: invalid conversion from ‘void*’ to ‘mowgli_json_t* {aka _mowgli_json_t*}’ [-fpermissive]
/usr/include/libmowgli-2/ext/json-inline.h: In function ‘mowgli_json_t* mowgli_json_object_delete(mowgli_json_t*, const char*)’:
/usr/include/libmowgli-2/ext/json-inline.h:88:60: error: invalid conversion from ‘void*’ to ‘mowgli_json_t* {aka _mowgli_json_t*}’ [-fpermissive]`
```
