### PR TITLE
Add compiler #error directive for glibc retadation

### DIFF
--- a/src/libmowgli/base/mowgli_signal.c
+++ b/src/libmowgli/base/mowgli_signal.c
@@ -26,6 +26,10 @@
 #include <signal.h>
 #include "mowgli.h"
 
+#if defined(__linux__) && defined(__GNUC__) && defined(__STRICT_ANSI__)
+#	error GCC/Linux in -std=c99 mode will not compile mowgli_signal; use -std=gnu99 instead
+#endif
+
 static mowgli_signal_handler_t
 mowgli_signal_install_handler_full(int signum, mowgli_signal_handler_t handler, int *sigtoblock, size_t sigtoblocksize)
 {


### PR DESCRIPTION
When compiling using GCC on Linux (not other platforms), and using the -std=c99 parameter, the compiler does `#include <bits/sigaction.h>` (this is actually an issue with glibc, imo, but what are you gonna do with that steaming pile).  This causes mowgli_signal.c to break hilariously, with the most stupid error messages ever.

This patch adds a much less stupid error message at the top, so people trying to build C99 code (or people using retarded distros that ship "-std=c99" in default CFLAGS) won't fall into the same trap.  Beyond pulling in bits/sigaction.h directly in these cases - which you could just `s$error.*$include <bits/sigaction.h>$` in this diff if you want to - there is no other satisfactory solution.

Bug is documented [here](http://forums.debian.net/viewtopic.php?t=6408) on Debian.

Future workarounds that I am too tired to write now could include:
- do not rely on `sigaction` being there since it is not "standard" and write something using just `signal` (LOL)
- do not allow compiling on glibc with -std=c99 (alpine, master race)
- directly `#include <bits/sigaction.h>` for poor saps stuck on glibc
