### PR TITLE
Fix IPv6 reverse DNS lookups (address to name conversion)

### DIFF
--- a/src/libmowgli/dns/evloop_res.c
+++ b/src/libmowgli/dns/evloop_res.c
@@ -713,7 +713,7 @@ do_query_number(mowgli_dns_t *dns, mowgli_dns_query_t *query, const struct socka
 				(unsigned int) (cp[i] & 0xf),
 				(unsigned int) (cp[i] >> 4));
 
-		strcpy(rqptr, ".ip6.arpa");
+		strcpy(rqptr, "ip6.arpa");
 	}
 	else
 	{


### PR DESCRIPTION
The bug here is that it reverses the octets and appends a period
after each nibble, but then prepends a period before ip6.arpa.

This results in a query with 2 consecutive periods, which then
goes on to fail query validation and so the query is never sent.

I have no idea how this failed basic quality testing especially
since there is an example program that uses this functionality
that was apparently not even extended to try IPv6.

(pull request on behalf of Aaron)