### PR TITLE
vio/vio.c: mowgli_vio_err_sslerrcode: Return correct type from assertion

### DIFF
--- a/src/libmowgli/vio/vio.c
+++ b/src/libmowgli/vio/vio.c
@@ -226,7 +226,7 @@ mowgli_vio_err_sslerrcode(mowgli_vio_t *vio, unsigned long int errcode)
 int
 mowgli_vio_err_sslerrcode(mowgli_vio_t *vio, unsigned long int errcode)
 {
-	return_if_fail(vio);
+	return_val_if_fail(vio, -255);
 
 	vio->error.type = MOWGLI_VIO_ERR_ERRCODE;
 	vio->error.code = errcode;


### PR DESCRIPTION
If compiled without OpenSSL, there is currently a `return_if_fail` assertion in `mowgli_vio_err_sslerrcode` which raises a return type mismatch warning on compile. Changed to return `-255` like its OpenSSL variant. (One assumes that this is an arbitrary return code, and not related to libssl.)