### PR TITLE
patricia.c: Fix assert in mowgli_patricia_elem_add

### DIFF
--- a/src/libmowgli/container/patricia.c
+++ b/src/libmowgli/container/patricia.c
@@ -710,9 +710,9 @@ mowgli_patricia_elem_add(mowgli_patricia_t *dict, const char *key, void *data)
 	int val, keylen;
 	int i, j;
 
-	return_val_if_fail(dict != NULL, FALSE);
-	return_val_if_fail(key != NULL, FALSE);
-	return_val_if_fail(data != NULL, FALSE);
+	return_val_if_fail(dict != NULL, NULL);
+	return_val_if_fail(key != NULL, NULL);
+	return_val_if_fail(data != NULL, NULL);
 
 	keylen = strlen(key);
 	ckey = mowgli_strdup(key);


### PR DESCRIPTION
Some boolean assert returns were left over from the partitioning of `mowgli_patricia_elem_add` from `mowgli_patricia_add`, which makes certain compilers unhappy.