### PR TITLE
cacheline: Ensure sysconf var is defined before use on Linux

### DIFF
--- a/src/libmowgli/platform/cacheline.c
+++ b/src/libmowgli/platform/cacheline.c
@@ -32,7 +32,7 @@ size_t cacheline_size;
 void
 mowgli_cacheline_bootstrap(void)
 {
-#ifdef MOWGLI_OS_LINUX
+#if defined(MOWGLI_OS_LINUX) && defined(_SC_LEVEL1_DCACHE_LINESIZE)
 	cacheline_size = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
 #elif defined(MOWGLI_OS_OSX)
 	size_t size = sizeof(size_t);


### PR DESCRIPTION
#43 #41

I couldn't understand how to pull this completely out of the build system so this just fixes it to build on musl.