### PR TITLE
Adding AUR link

### DIFF
--- a/README
+++ b/README
@@ -68,6 +68,9 @@ Installation is fairly typical:
 (If sudo isn't on your system, su to root. On GNU systems you can even do
 "su -c 'make install'", which is basically the same thing as using sudo.)
 
+There is also an Arch User Repository package available here:
+https://aur.archlinux.org/packages/libmowgli-2-git/
+
 
 Bug Reports
 -----------


### PR DESCRIPTION
Hello!

I find libmowgli-2 really useful, so I decided to package it for the [Arch User Repository](https://aur.archlinux.org/packages/libmowgli-2-git/). I was thinking it might be a good idea to provide a link to it in the README for the convenience of other Arch users who use this library. Thanks!